### PR TITLE
Add username and password authentication to Sem6000MqttClient

### DIFF
--- a/src/main/java/org/magcode/sem6000/mqtt/Sem6000MqttClient.java
+++ b/src/main/java/org/magcode/sem6000/mqtt/Sem6000MqttClient.java
@@ -28,6 +28,8 @@ public class Sem6000MqttClient {
 	private static MqttClient mqttClient;
 	private static String rootTopic = "home/sem";
 	private static String mqttServer = "tcp://broker";
+	private static String username = "";
+	private static char[] password;
 	private static int consecutiveReconnectLimit = 100;
 	private static final int MAX_INFLIGHT = 200;
 	private static Map<String, Sem6000Config> sems;
@@ -88,6 +90,11 @@ public class Sem6000MqttClient {
 		connOpt.setCleanSession(true);
 		connOpt.setMaxInflight(MAX_INFLIGHT);
 		connOpt.setAutomaticReconnect(true);
+		if (username != null && !username.isEmpty() && password != null && password.length > 0) {
+			connOpt.setUserName(username);
+			connOpt.setPassword(password);
+			java.util.Arrays.fill(password, '\0');
+		}
 		mqttSubscriber = new MqttSubscriber(mqttClient, rootTopic, sems);
 		mqttClient.setCallback(mqttSubscriber);
 		mqttClient.connect(connOpt);
@@ -108,6 +115,8 @@ public class Sem6000MqttClient {
 
 			rootTopic = props.getProperty("rootTopic", "home");
 			mqttServer = props.getProperty("mqttServer", "tcp://localhost");
+			username = props.getProperty("username", null);
+			password = props.getProperty("password", null).toCharArray();
 			consecutiveReconnectLimit = Integer.valueOf(props.getProperty("maxReconnects", "100"));
 			Enumeration<?> e = props.propertyNames();
 			while (e.hasMoreElements()) {


### PR DESCRIPTION
This pull request includes changes to the `Sem6000MqttClient` class to add support for MQTT authentication using a username and password. The most important changes include the addition of new fields for the username and password, updating the MQTT client connection options to use these credentials, and reading the credentials from properties.

Authentication support:

* [`src/main/java/org/magcode/sem6000/mqtt/Sem6000MqttClient.java`](diffhunk://#diff-85932932a34bc6d93d72cb8bfbe4d94cc5b322bf6411c2ea87e633804798e0d6R31-R32): Added `username` and `password` fields to store MQTT credentials.
* [`src/main/java/org/magcode/sem6000/mqtt/Sem6000MqttClient.java`](diffhunk://#diff-85932932a34bc6d93d72cb8bfbe4d94cc5b322bf6411c2ea87e633804798e0d6R93-R97): Updated `startMQTTClient` method to set the username and password in the connection options if they are provided.
* [`src/main/java/org/magcode/sem6000/mqtt/Sem6000MqttClient.java`](diffhunk://#diff-85932932a34bc6d93d72cb8bfbe4d94cc5b322bf6411c2ea87e633804798e0d6R118-R119): Modified `readProps` method to read `username` and `password` from properties and convert the password to a character array.